### PR TITLE
Keep GPMDP

### DIFF
--- a/bucket/gpmdp.json
+++ b/bucket/gpmdp.json
@@ -1,0 +1,24 @@
+{
+    "homepage": "https://www.googleplaymusicdesktopplayer.com/",
+    "description": "A beautiful cross platform Desktop Player for Google Play Music",
+    "version": "4.7.1",
+    "license": "MIT",
+    "url": "https://github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL-/releases/download/v4.7.1/GPMDP_3-4.7.1-full.nupkg#/dl.7z",
+    "hash": "sha1:bc5bea436af2ed7af8b822d02f76e0fae09f8192",
+    "extract_dir": "lib/net45",
+    "shortcuts": [
+        [
+            "Google%20Play%20Music%20Desktop%20Player.exe",
+            "Google Play Music Desktop Player (GPMDP)"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL-"
+    },
+    "autoupdate": {
+        "url": "https://github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL-/releases/download/v$version/GPMDP_3-$version-full.nupkg#/dl.7z",
+        "hash": {
+            "url": "$baseurl/RELEASES"
+        }
+    }
+}


### PR DESCRIPTION
This reverts commit 7ee80a5f6bdc51599a38cf1cb7bedf787957ad3b.

While Google Play Music is going away, GPMDP works just as well for its
replacement, YouTube Music.